### PR TITLE
error handling at connector level

### DIFF
--- a/GitHubWebUserFinder.Tests/Connectors/GitHubConnectorTests.cs
+++ b/GitHubWebUserFinder.Tests/Connectors/GitHubConnectorTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -91,6 +93,91 @@ namespace GitHubWebUserFinder.Tests.Services
 			GitHubUser result = await connector.FindUser("test");
 
 			Assert.AreEqual(result.Repositories.ToList().Count, expectedRepositories.Count);
+		}
+
+		[Test]
+		public async Task AGitHubConnector_WillThrowA404Exception_IfUserDoesNotExist()
+		{
+			var expectedResponseFromGitHub = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.NotFound,
+				Content = new StringContent(@"User has not been found")
+			};
+
+			Mock<IAppHttpClient> appHttpClient = new Mock<IAppHttpClient>();
+			appHttpClient.Setup(c => c.Get(It.IsAny<string>()))
+				.ReturnsAsync(expectedResponseFromGitHub);
+
+
+			GitHubConnector connector = new GitHubConnector(appHttpClient.Object);
+
+			Assert.That(async() => await connector.FindUser("test"), Throws.Exception.TypeOf<GitHubUserNotFoundException>().And.Message.EqualTo("GitHub user not found"));
+		}
+
+		[Test]
+		public async Task AGitHubConnector_WillThrowServiceUnavailableException_IfGitHubIsNotAvailable()
+		{
+			var expectedResponseFromGitHub = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.ServiceUnavailable,
+				Content = new StringContent(@"Git is not ready at the moment")
+			};
+
+			Mock<IAppHttpClient> appHttpClient = new Mock<IAppHttpClient>();
+			appHttpClient.Setup(c => c.Get(It.IsAny<string>()))
+				.ReturnsAsync(expectedResponseFromGitHub);
+
+
+			GitHubConnector connector = new GitHubConnector(appHttpClient.Object);
+
+			Assert.That(async () => await connector.FindUser("test"), Throws.Exception.TypeOf<SearchFunctionalityNotAvailableException>().And.Message.EqualTo("Find functionality is not available at the minute"));
+		}
+
+		[Test]
+		public async Task AGitHubConnector_WhenThrowingUnrecognizedException_WillBubbleUpHttpRequestException()
+		{
+			var expectedResponseFromGitHub = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.UpgradeRequired,
+				Content = new StringContent(@"We have a problem")
+			};
+
+			Mock<IAppHttpClient> appHttpClient = new Mock<IAppHttpClient>();
+			appHttpClient.Setup(c => c.Get(It.IsAny<string>()))
+				.ReturnsAsync(expectedResponseFromGitHub);
+
+
+			GitHubConnector connector = new GitHubConnector(appHttpClient.Object);
+
+			Assert.That(async () => await connector.FindUser("test"), Throws.Exception.TypeOf<HttpRequestException>());
+		}
+
+		[Test]
+		public async Task
+			AGitHubConnector_WhenFetchingUsersRepositories_IfNotSuccess_ThenConsiderTheWholeTransactionAsFailed_AndThrowExceptionAccordingly()
+		{
+			var expectedResponseFromGitHub = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.OK,
+				Content = new StringContent(@"{login:'test'}")
+			};
+
+			var expectedRepositories = Generators.JsonGitHubRepositories.Sample(50, 1).First();
+
+			var expectedRepositoriesResponse = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.UpgradeRequired,
+				Content = new StringContent(@"We have a problem")
+			};
+
+			Mock<IAppHttpClient> appHttpClient = new Mock<IAppHttpClient>();
+			appHttpClient.SetupSequence(c => c.Get(It.IsAny<string>()))
+				.ReturnsAsync(expectedResponseFromGitHub)
+				.ReturnsAsync(expectedRepositoriesResponse);
+
+			GitHubConnector connector = new GitHubConnector(appHttpClient.Object);
+
+			Assert.That(async () => await connector.FindUser("test"), Throws.Exception.TypeOf<HttpRequestException>());
 		}
 	}
 }

--- a/GitHubWebUserFinder/Exceptions/GitHubUserNotFoundException.cs
+++ b/GitHubWebUserFinder/Exceptions/GitHubUserNotFoundException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace GitHubWebUserFinder.Connectors
+{
+	public class GitHubUserNotFoundException : Exception
+	{
+		public GitHubUserNotFoundException(string message, Exception inner)
+			: base(message, inner)
+		{
+		}
+	}
+}

--- a/GitHubWebUserFinder/Exceptions/SearchFunctionalityNotAvailableException.cs
+++ b/GitHubWebUserFinder/Exceptions/SearchFunctionalityNotAvailableException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace GitHubWebUserFinder.Connectors
+{
+	public class SearchFunctionalityNotAvailableException : Exception
+	{
+		public SearchFunctionalityNotAvailableException(string message, Exception inner)
+			: base(message, inner)
+		{
+		}
+	}
+}

--- a/GitHubWebUserFinder/GitHubWebUserFinder.csproj
+++ b/GitHubWebUserFinder/GitHubWebUserFinder.csproj
@@ -156,9 +156,11 @@
     <Compile Include="App_Start\UnityConfig.cs" />
     <Compile Include="Connectors\AppHttpClient.cs" />
     <Compile Include="Connectors\GitHubConnector.cs" />
+    <Compile Include="Exceptions\GitHubUserNotFoundException.cs" />
     <Compile Include="Connectors\HttpClientFactory.cs" />
     <Compile Include="Connectors\IAppHttpClient.cs" />
     <Compile Include="Connectors\IGitHubConnector.cs" />
+    <Compile Include="Exceptions\SearchFunctionalityNotAvailableException.cs" />
     <Compile Include="Controllers\ResultController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Global.asax.cs">


### PR DESCRIPTION
**Implementing error handling at connector level**

- Custom errors are for Users not founds and Service Unavailable. Then we will be able to bubble these up to Controller and redirect to appropriate informative page.
- If search for users repositories does not succeed, then we consider THE WHOLE transaction (including user) as failed.