### PR TITLE
swapping system.web errors with IIS error handling

### DIFF
--- a/GitHubWebUserFinder/Web.config
+++ b/GitHubWebUserFinder/Web.config
@@ -13,15 +13,22 @@
   <system.web>
     <compilation debug="true" targetFramework="4.6.1" />
     <httpRuntime targetFramework="4.6.1" />
-    <customErrors mode="On" defaultRedirect="~/Error/SomethingWentWrong">
-      <error statusCode="404" redirect="~/Error/SomethingWentWrong"/>
-      <error statusCode="500" redirect="~/Error/SomethingWentWrong"/>
-    </customErrors>
   </system.web>
   <system.webServer>
     <handlers>
       <add name="ApiURIs-ISAPI-Integrated-4.0" path="/Result/Search/*" verb="GET" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
+    <httpErrors errorMode="Custom" existingResponse="Replace">
+      <clear/>
+      <error
+        statusCode="404"
+        path="/Error/SomethingWentWrong"
+        responseMode="ExecuteURL"/>
+      <error
+        statusCode="500"
+        path="/Error/SomethingWentWrong"
+        responseMode="ExecuteURL"/>
+    </httpErrors>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
* Swapping errors in web.config rather than being done at ASP.NET level (system.web), do it at IIS level (a level further up the chain, within system.webserver)